### PR TITLE
Added functionality to set complete AC state

### DIFF
--- a/pysensibo/__init__.py
+++ b/pysensibo/__init__.py
@@ -86,6 +86,24 @@ class SensiboClient(object):
         raise SensiboError((yield from resp.text()))
 
     @asyncio.coroutine
+    def async_set_ac_state(self, uid, payload):
+        """Set a complete device state"""
+        data = {
+            'acState': payload
+        }
+
+        resp = yield from self._session.post(
+            _SERVER + '/pods/{}/acStates'.format(uid),
+            data=json.dumps(data),
+            params=self._params,
+            timeout=self._timeout)
+        try:
+            return (yield from resp.json())['result']
+        except aiohttp.client_exceptions.ContentTypeError:
+            pass
+        raise SensiboError((yield from resp.text()))
+
+    @asyncio.coroutine
     def _get(self, path, **kwargs):
         resp = yield from self._session.get(
             _SERVER + path, params=dict(self._params, **kwargs),


### PR DESCRIPTION
Added extra API call to [Set the AC state](https://sensibo.github.io/#/paths/~1pods~1{device_id}~1acStates/post) which sets the full AC state in one go. 
The aim here is to add a Sensibo specific service to HomeAssistant such that the complete state can be set without requiring individual commands.