### PR TITLE
Fix pm25 for pure device

### DIFF
--- a/pysensibo/__init__.py
+++ b/pysensibo/__init__.py
@@ -244,7 +244,12 @@ class SensiboClient:
                     "measurements_integration", False
                 )
                 pure_prime_integration = pure_conf.get("prime_integration", False)
-            pm25 = measure.get("pm25")
+            if dev["productModel"] != "pure":
+                pm25 = measure.get("pm25")
+                pm25_pure = measure.get("pm25")
+            else:
+                pm25 = measure.get("pm25")
+                pm25_pure = measure.get("pm25")
 
             # Binary sensors for main device
             room_occupied = dev["roomIsOccupied"]
@@ -389,6 +394,7 @@ class SensiboClient:
                 pure_prime_integration=pure_prime_integration,
                 pure_conf=pure_conf,
                 pm25=pm25,
+                pm25_pure=pm25_pure,
                 room_occupied=room_occupied,
                 update_available=update_available,
                 filter_clean=filter_clean,

--- a/pysensibo/model.py
+++ b/pysensibo/model.py
@@ -61,6 +61,7 @@ class SensiboDevice:
     full_capabilities: dict[str, Any]
     motion_sensors: dict[str, MotionSensor] | None
     pm25: float | None
+    pm25_pure: int | None
     room_occupied: bool
     update_available: bool
     schedules: dict[str, Schedules] | None


### PR DESCRIPTION
# Proposed Changes

Adds special pm25 value for Pure device as it's actually not pm25 but some aqi index value
https://github.com/home-assistant/core/issues/117705#issuecomment-2217298395

## Related Issues

https://github.com/home-assistant/core/issues/117705

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
